### PR TITLE
Update uv instructions with correct command syntax

### DIFF
--- a/.github/instructions/uv.instructions.md
+++ b/.github/instructions/uv.instructions.md
@@ -4,10 +4,12 @@ applyTo: '**'
 
 1. Use uv for Python environment setup and package management.
 
-2. Run `uv ruff` to check code style and linting issues.
+2. Run `uv run ruff` to check code style and linting issues.
 
-3. Run `uv pytest` to execute the test suite and verify that all tests pass.
+3. Run `uv run pytest` to execute the test suite and verify that all tests pass.
 
-4. Use `uv build` to create a distributable package for your project.
+4. Run `uv run mypy .` to perform static type checking.
 
-5. Use `uv publish` to publish your package to PyPI.
+5. Use `uv build` to create a distributable package for your project.
+
+6. Use `uv publish` to publish your package to PyPI.


### PR DESCRIPTION
Fix incorrect uv command syntax in instructions. Changed 'uv ruff' to 'uv run ruff', 'uv pytest' to 'uv run pytest', and added 'uv run mypy .' for type checking. The previous commands were invalid uv subcommands that would fail.