### PR TITLE
Add GitHub CLI instructions to separate file

### DIFF
--- a/.github/instructions/gh.instructions.md
+++ b/.github/instructions/gh.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: '**'
+---
+
+1. Use `gh` command to manage GitHub operations:
+   - `gh issue create --title "Title" --body "Description"` to create issues
+   - `gh pr create --title "Title" --body "Description"` to create pull requests
+   - `gh pr merge <number> --squash --delete-branch` to merge and clean up
+   - `gh pr view <number>` to view pull request details
+   - `gh issue list` and `gh pr list` to view issues and pull requests


### PR DESCRIPTION
Creates a dedicated gh.instructions.md file for GitHub CLI commands and keeps uv.instructions.md focused only on uv-specific operations. This improves organization and separation of concerns. Closes #12